### PR TITLE
Allow user to provide *http.Client when constructing JsonApiGateway

### DIFF
--- a/cpanel/authenticated.go
+++ b/cpanel/authenticated.go
@@ -29,6 +29,23 @@ func NewJsonApi(hostname, username, password string, insecure bool) (CpanelApi, 
 		Password: password,
 		Insecure: insecure,
 	}
+
+	// todo: a way to check the username/password here
+	return CpanelApi{cpanelgo.NewApi(c)}, nil
+}
+
+func NewJsonApiWithClient(hostname, username, password string, insecure bool, cl *http.Client) (CpanelApi, error) {
+	c := &JsonApiGateway{
+		Hostname: hostname,
+		Username: username,
+		Password: password,
+		Insecure: insecure,
+	}
+
+	if cl != nil {
+		c.cl = cl
+	}
+
 	// todo: a way to check the username/password here
 	return CpanelApi{cpanelgo.NewApi(c)}, nil
 }

--- a/cpanel/authenticated.go
+++ b/cpanel/authenticated.go
@@ -40,10 +40,7 @@ func NewJsonApiWithClient(hostname, username, password string, insecure bool, cl
 		Username: username,
 		Password: password,
 		Insecure: insecure,
-	}
-
-	if cl != nil {
-		c.cl = cl
+		cl:       cl,
 	}
 
 	// todo: a way to check the username/password here

--- a/example/cpanelcli.go
+++ b/example/cpanelcli.go
@@ -130,7 +130,7 @@ func modeCpanel() {
 	required(password, "Please specify a password")
 	required(version, "Please specify an api version")
 
-	cl, err := cpanel.NewJsonApi(hostname, username, password, insecure, nil)
+	cl, err := cpanel.NewJsonApi(hostname, username, password, insecure)
 	ifpanic(err)
 
 	/*

--- a/example/cpanelcli.go
+++ b/example/cpanelcli.go
@@ -130,7 +130,7 @@ func modeCpanel() {
 	required(password, "Please specify a password")
 	required(version, "Please specify an api version")
 
-	cl, err := cpanel.NewJsonApi(hostname, username, password, insecure)
+	cl, err := cpanel.NewJsonApi(hostname, username, password, insecure, nil)
 	ifpanic(err)
 
 	/*

--- a/whm/impersonation.go
+++ b/whm/impersonation.go
@@ -1,6 +1,7 @@
 package whm
 
 import (
+	"net/http"
 	"strings"
 
 	"encoding/json"
@@ -26,6 +27,23 @@ func NewWhmImpersonationApi(hostname, username, accessHash, userToImpersonate st
 				Username:   username,
 				AccessHash: accessHash,
 				Insecure:   insecure,
+			},
+		})}
+}
+
+func NewWhmImpersonationApiWithClient(hostname, username, accessHash, userToImpersonate string, insecure bool, cl *http.Client) cpanel.CpanelApi {
+	accessHash = strings.Replace(accessHash, "\n", "", -1)
+	accessHash = strings.Replace(accessHash, "\r", "", -1)
+
+	return cpanel.CpanelApi{cpanelgo.NewApi(
+		&WhmImpersonationApi{
+			Impersonate: userToImpersonate,
+			WhmApi: WhmApi{
+				Hostname:   hostname,
+				Username:   username,
+				AccessHash: accessHash,
+				Insecure:   insecure,
+				cl:         cl,
 			},
 		})}
 }

--- a/whm/whm.go
+++ b/whm/whm.go
@@ -84,6 +84,19 @@ func NewWhmApiAccessHash(hostname, username, accessHash string, insecure bool) W
 	}
 }
 
+func NewWhmApiAccessHashWithClient(hostname, username, accessHash string, insecure bool, cl *http.Client) WhmApi {
+	accessHash = strings.Replace(accessHash, "\n", "", -1)
+	accessHash = strings.Replace(accessHash, "\r", "", -1)
+
+	return WhmApi{
+		Hostname:   hostname,
+		Username:   username,
+		AccessHash: accessHash,
+		Insecure:   insecure,
+		cl:         cl,
+	}
+}
+
 func NewWhmApiAccessHashTotp(hostname, username, accessHash string, insecure bool, secret string) WhmApi {
 	accessHash = strings.Replace(accessHash, "\n", "", -1)
 	accessHash = strings.Replace(accessHash, "\r", "", -1)


### PR DESCRIPTION
Fixes #4 